### PR TITLE
feat: limit display urls and add flags for overrides

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,5 +105,9 @@ jobs:
         run: |
           uv run crx-analyzer analyze --id nnkgneoiohoecpdiaponcejilbhhikei --browser edge --output pretty
           uv run crx-analyzer analyze --id eaijffijbobmnonfhilihbejadplhddo --browser chrome --output pretty
+          uv run crx-analyzer analyze --id ojkchikaholjmcnefhjlbohackpeeknd --browser chrome --output pretty --permissions
+          uv run crx-analyzer analyze --id ojkchikaholjmcnefhjlbohackpeeknd --browser chrome --output pretty --max-files 20
+          uv run crx-analyzer analyze --id ojkchikaholjmcnefhjlbohackpeeknd --browser chrome --output pretty --max-urls 20
+
 
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,19 @@ crx-analyzer analyze --id eaijffijbobmnonfhilihbejadplhddo --browser edge --outp
 Output extension results to json format
 
 ```bash
-crx-analyzer analyze --id eaijffijbobmnonfhilihbejadplhddo --browser chrome --output json
+crx-analyzer analyze --id eaijffijbobmnonfhilihbejadplhddo --browser edge --output json
+```
+
+Show only permissions and metadata in pretty mode
+
+```bash
+crx-analyzer analyze --id eaijffijbobmnonfhilihbejadplhddo --browser edge --permissions
+```
+
+Limit the number of JavaScript files displayed to 20
+
+```bash
+crx-analyzer analyze --id eaijffijbobmnonfhilihbejadplhddo --browser edge --max-files 20
 ```
 
 # Development


### PR DESCRIPTION
This PR adds `--limit-urls`, `--limit-files`, and `--permissions`. A default limit of 10 URLs and files is applied to prevent terminal spam in pretty mode. `--limit-files` and `--limit-urls` provide overrides to the limit, and `--permissions` can be used to show only permissions and metadata from the extension.

Fixes #21 